### PR TITLE
Destroy dependent dangling provider subscriptions

### DIFF
--- a/app/models/billing/subscription.rb
+++ b/app/models/billing/subscription.rb
@@ -2,7 +2,7 @@ class Billing::Subscription < ApplicationRecord
   # 🚅 add concerns above.
 
   belongs_to :team
-  belongs_to :provider_subscription, polymorphic: true
+  belongs_to :provider_subscription, dependent: :destroy, polymorphic: true
   # 🚅 add belongs_to associations above.
 
   has_many :included_prices, class_name: "Billing::Subscriptions::IncludedPrice", dependent: :destroy, foreign_key: :subscription_id


### PR DESCRIPTION
Situation – Generic subscriptions can be destroyed in several (?) ways, including when users click the subscription's “cancel” link instead of completing a purchase. Note that this happens a lot, because clicking this link is the only way that users can change a pricing plan they've chosen, if they change their mind before paying. And there are probably other circumstances when generic subscriptions are deleted.

Impact – When the provider subscription is not destroyed, the database accumulates orphaned provider subscriptions (which remain associated with teams). The presence of these dangling provider subscriptions adds more edge cases to code that deals with provider subscriptions. I found this issue because my custom code that worked with provider subscriptions began erroring in production.

Proposed improvement – Destroy the associated provider descriptions when a generic subscription is destroyed.

Other links – See conversation in Discord [here](https://discord.com/channels/836637622432170028/836637623048601633/threads/1053105075540729916).