### PR TITLE
Reload entire page when accessing the pricing page

### DIFF
--- a/app/views/account/billing/subscriptions/_index.html.erb
+++ b/app/views/account/billing/subscriptions/_index.html.erb
@@ -17,7 +17,7 @@
           <% p.content_for :title, "Free Plan" %>
           <% p.content_for :status, "Active" %>
           <% p.content_for :actions do %>
-            <%= link_to "Upgrade", [:new, :account, team, :billing_subscription], class: "button button-smaller new" %>
+            <%= link_to "Upgrade", [:new, :account, team, :billing_subscription], class: "button button-smaller new", target: "_top" %>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
Closes #8.
@jagthedrummer

Upon inspecting the html:
## When initially accessing the page
```html
Pricing layout theme
<!--BEGIN /home/gazayas/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bullet_train-1.2.26/app/views/layouts.account.html.erb-->
<!--BEGIN /home/gazayas/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bullet_train-themes-light-1.2.26/app/views/themes/light/layouts/_account.html.erb-->
<!DOCTYPE html>
<html class="theme-emerald ">
<head>...</head>
<body class="pricing-page-background">...</body>
</html>
<!-- END ...-->
<!-- END ...-->
```

## After reloading
```html
<!-- BEGIN local/bullet_train-billing/app/views/layouts/pricing.html.erb -->
<!-- BEGIN /home/gazayas/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bullet_train-themes-light-1.2.26/app/views/themes/light/layouts/_pricing.html.erb -->
<!DOCTYPE html>
<html>
<head>...</head>
<body class="pricing-page-background"> (turbo stuff...) </body>
</html>
<!-- END ...-->
<!-- END ...-->
```

## Turbo docs
I came across a thread that pointed to the [Turbo docs](https://turbo.hotwired.dev/reference/frames#frame-targeting-the-whole-page-by-default) that say to use `target="_top"` to refresh the whole page:

```html
<turbo-frame id="messages" target="_top">
  <a href="/messages/1">
    Following link will replace the whole page, not this frame.
  </a>

  <a href="/messages/1" data-turbo-frame="_self">
    Following link will replace just this frame.
  </a>

  <form action="/messages">
    Submitting form will replace the whole page, not this frame.
  </form>
</turbo-frame>
```

## Support for other themes
I'm not sure if we want to support other themes right now, so I think it'll be best to just use the default blue we have in place now.