### PR TITLE
Add a field to allow promo codes

### DIFF
--- a/app/models/billing/price.rb
+++ b/app/models/billing/price.rb
@@ -5,6 +5,7 @@ class Billing::Price < ApplicationHash
   field :interval
   field :trial_days
   field :quantity
+  field :allow_promotion_codes
 
   self.data = YAML.load_file("config/models/billing/products.yml").map do |product_id, product|
     if product["prices"]


### PR DESCRIPTION
This lays the ground work for being able to implement a fix for https://github.com/bullet-train-pro/bullet_train-billing-stripe/issues/5

Now a product price in `products.yml` can contain an `allow_promotion_codes` key that accepts a boolean.

```yaml
basic:
  price: basic_2023
  image: "vol1.png"
  limits:
    # snip
  prices:
    basic_monthly_2023:
      amount: 800
      currency: USD
      duration: 1
      interval: month
      allow_promotion_codes: true
    basic_annual_2023:
      amount: 8000
      currency: USD
      duration: 1
      interval: year
      allow_promotion_codes: false
```

When someone goes to subscribe to a plan that supports coupon codes they'll see this during checkout:

![CleanShot 2023-06-20 at 11 00 00](https://github.com/bullet-train-pro/bullet_train-billing/assets/58702/0a8c13eb-3a25-4330-a612-d3bd1b00d2ac)


![CleanShot 2023-06-20 at 11 00 16](https://github.com/bullet-train-pro/bullet_train-billing/assets/58702/037a6bdd-2f28-41d4-b265-ed9932fa910f)
