### PR TITLE
Use Teams::Base load hook to insert functionality

### DIFF
--- a/lib/bullet_train/billing.rb
+++ b/lib/bullet_train/billing.rb
@@ -3,10 +3,31 @@ require "bullet_train/billing/engine"
 
 module BulletTrain
   module Billing
-    # Your code goes here...
+    module Teams
+      module Base
+        extend ActiveSupport::Concern
+
+        included do
+          has_many :billing_subscriptions, class_name: "Billing::Subscription", dependent: :destroy, foreign_key: :team_id
+        end
+
+        def current_billing_subscription
+          # If by some bug we have two subscriptions, we want to use the one that existed first.
+          # The reasoning here is that it's more likely to be on some legacy plan that benefits the customer.
+          billing_subscriptions.active.order(:created_at).first
+        end
+
+        def needs_billing_subscription?
+          return false if freemium_enabled?
+          billing_subscriptions.active.empty?
+        end
+      end
+    end
   end
 end
 
 def freemium_enabled?
   Billing::Product.find_by(id: "free").present?
 end
+
+ActiveSupport.on_load(:bullet_train_teams_base) { include BulletTrain::Billing::Teams::Base }


### PR DESCRIPTION
This work is dependent on https://github.com/bullet-train-co/bullet_train-core/pull/335 being shipped.

Then we're just grabbing the bullet_train-billing specific extensions and pulling them in to our repo. Note: we can skip the surrounding `billing_enabled?` checks, since we already know its enabled by the fact that we're loading the very library.