### PR TITLE
Use load hooks to insert functionality

### DIFF
--- a/app/controllers/account/billing/subscriptions_controller.rb
+++ b/app/controllers/account/billing/subscriptions_controller.rb
@@ -125,6 +125,8 @@ class Account::Billing::SubscriptionsController < Account::ApplicationController
         # Umbrella subscription attributes:
         :covering_team_id,
 
+        *BulletTrain::Billing.provider_subscription_attributes,
+
         # External subscription attributes:
         :notes
       ]

--- a/app/models/concerns/billing/ability_support.rb
+++ b/app/models/concerns/billing/ability_support.rb
@@ -27,4 +27,6 @@ module Billing::AbilitySupport
     # You can destroy subscriptions that haven't been checked out yet.
     can :destroy, Billing::Subscription, team_id: user.administrating_team_ids, status: "initiated"
   end
+
+  ActiveSupport.run_load_hooks :bullet_train_billing_ability_support, self
 end

--- a/lib/bullet_train/billing.rb
+++ b/lib/bullet_train/billing.rb
@@ -3,6 +3,29 @@ require "bullet_train/billing/engine"
 
 module BulletTrain
   module Billing
+    module Records
+      module Base
+        extend ActiveSupport::Concern
+
+        included do
+          # By default, any model in a collection is considered active for billing purposes.
+          # This can be overloaded in the child model class to specify more specific criteria for billing.
+          # See `Memberships::Base` below for an example.
+          scope :billable, -> { order("TRUE") } # TODO: Replace empty condition with just `all` to return the current relation.
+        end
+      end
+    end
+
+    module Memberships
+      module Base
+        extend ActiveSupport::Concern
+
+        included do
+          scope :billable, -> { current_and_invited }
+        end
+      end
+    end
+
     module Teams
       module Base
         extend ActiveSupport::Concern
@@ -30,4 +53,7 @@ def freemium_enabled?
   Billing::Product.find_by(id: "free").present?
 end
 
+ActiveSupport.on_load(:bullet_train_records_base) { include BulletTrain::Billing::Records::Base }
+ActiveSupport.on_load(:bullet_train_memberships_base) { include BulletTrain::Billing::Memberships::Base }
 ActiveSupport.on_load(:bullet_train_teams_base) { include BulletTrain::Billing::Teams::Base }
+ActiveSupport.on_load(:bullet_train_account_controllers_base) { include Billing::ControllerSupport }

--- a/lib/bullet_train/billing.rb
+++ b/lib/bullet_train/billing.rb
@@ -3,10 +3,31 @@ require "bullet_train/billing/engine"
 
 module BulletTrain
   module Billing
-    # Your code goes here...
+    module Teams
+      module Base
+        extend ActiveSupport::Concern
+
+        included do
+          has_many :billing_subscriptions, class_name: "Billing::Subscription", dependent: :destroy, foreign_key: :team_id
+        end
+
+        def current_billing_subscription
+          # If by some bug we have two subscriptions, we want to use the one that existed first.
+          # The reasoning here is that it's more likely to be on some legacy plan that benefits the customer.
+          billing_subscriptions.active.order(:created_at).first
+        end
+
+        def needs_billing_subscription?
+          return false if freemium_enabled?
+          billing_subscriptions.active.empty?
+        end
+      end
+    end
   end
 end
 
 def freemium_enabled?
   Billing::Product.find_by(id: "free").present?
 end
+
+ActiveSupport.on_load(:bullet_train_teams_base) { include BulletTrain::Billing::Teams::Base }

--- a/lib/bullet_train/billing.rb
+++ b/lib/bullet_train/billing.rb
@@ -3,6 +3,9 @@ require "bullet_train/billing/engine"
 
 module BulletTrain
   module Billing
+    singleton_class.attr_reader :provider_subscription_attributes
+    @provider_subscription_attributes = []
+
     module Records
       module Base
         extend ActiveSupport::Concern


### PR DESCRIPTION
This work is dependent on https://github.com/bullet-train-co/bullet_train-core/pull/335 being shipped.

Then we're just grabbing the bullet_train-billing specific extensions and pulling them in to our repo. Note: we can skip the surrounding `billing_enabled?` checks, since we already know its enabled by the fact that we're loading the very library.

- [x] Figure out how to hook into https://github.com/bullet-train-pro/bullet_train-billing/blob/b4c5e56a71c4fb9bba84ffc0882a9f1ec4135e90/app/controllers/account/billing/subscriptions_controller.rb#L120