### PR TITLE
Notify provider gems of quantity changes

### DIFF
--- a/lib/bullet_train/billing/engine.rb
+++ b/lib/bullet_train/billing/engine.rb
@@ -17,7 +17,7 @@ module BulletTrain
           # return if quantity hasn't changed
           next if included_price[:quantity] == new_quantity
 
-          ActiveSupport::Notifications.instrument("memberships.provider-quantity-changed", {provider_subscription: billing_subscription.provider_subscription, included_price:, quantity: new_quantity})
+          ActiveSupport::Notifications.instrument("memberships.provider-subscription-quantity-changed", {provider_subscription: billing_subscription.provider_subscription, included_price:, quantity: new_quantity})
         end
       end
     end

--- a/lib/bullet_train/billing/engine.rb
+++ b/lib/bullet_train/billing/engine.rb
@@ -1,6 +1,25 @@
 module BulletTrain
   module Billing
     class Engine < ::Rails::Engine
+      initializer "bullet_train-billing.quantity" do
+        ActiveSupport::Notifications.subscribe("memberships.quantity-changed") do |_name, _start, _finish, _id, payload|
+          billing_subscription = payload[:team].billing_subscriptions.first
+
+          next unless billing_subscription.present?
+
+          included_price = billing_subscription.included_prices.first
+
+          # if not billing per seat, return
+          next unless included_price.price[:quantity] == "memberships"
+
+          new_quantity = included_price.price.calculate_quantity(payload[:team])
+
+          # return if quantity hasn't changed
+          next if included_price[:quantity] == new_quantity
+          
+          ActiveSupport::Notifications.instrument("memberships.provider-quantity-changed", {provider_subscription: billing_subscription.provider_subscription, included_price:, quantity: new_quantity})
+        end
+      end
     end
   end
 end

--- a/lib/bullet_train/billing/engine.rb
+++ b/lib/bullet_train/billing/engine.rb
@@ -3,7 +3,7 @@ module BulletTrain
     class Engine < ::Rails::Engine
       initializer "bullet_train-billing.quantity" do
         ActiveSupport::Notifications.subscribe("memberships.quantity-changed") do |_name, _start, _finish, _id, payload|
-          billing_subscription = payload[:team].billing_subscriptions.first
+          billing_subscription = payload[:team].current_billing_subscription
 
           next unless billing_subscription.present?
 

--- a/lib/bullet_train/billing/engine.rb
+++ b/lib/bullet_train/billing/engine.rb
@@ -16,7 +16,7 @@ module BulletTrain
 
           # return if quantity hasn't changed
           next if included_price[:quantity] == new_quantity
-          
+
           ActiveSupport::Notifications.instrument("memberships.provider-quantity-changed", {provider_subscription: billing_subscription.provider_subscription, included_price:, quantity: new_quantity})
         end
       end


### PR DESCRIPTION
This servers as a mediator between BT core and the provider gems: It catches the raw `quantity-changed` event, does some sanity checks and returns early if they don't pass, then just sends the necessary data on to the provider gems.